### PR TITLE
Fix return statement in NameList::get() method

### DIFF
--- a/arduino/Wi-PWN/NameList.cpp
+++ b/arduino/Wi-PWN/NameList.cpp
@@ -57,8 +57,8 @@ String NameList::get(int num) {
       if (names[num][h] != 0x00) returnStr += (char)names[num][h];
     }
     returnStr.trim();
-    return returnStr;
   }
+  return returnStr;
 }
 
 Mac NameList::getMac(int num) {


### PR DESCRIPTION
I was trying to compile the project on an ESP8266 and encountered this error:
```
the fix was simple, just moving the return statement of the function "NameList::get(int num)" from line 60 to 61 in the file "NameList.cpp", here's the code:
[code]
I would like others not to have the same error, even though it's a simple mistake, beginners might get discouraged and waste hours. Thank you in advance.
```
the fix was simple, just moving the return statement of the function "NameList::get(int num)" from line 60 to 61 in the file "NameList.cpp", here's the code:
```
String NameList::get(int num) {
  String returnStr;
  if (num >= 0) {
    for (int h = 0; h < nameLength; h++) {
      if (names[num][h] != 0x00) returnStr += (char)names[num][h];
    }
    returnStr.trim();
  }
  return returnStr;
}
```
I would like others not to have the same error, even though it's a simple mistake, beginners might get discouraged and waste hours. Thank you.